### PR TITLE
組織情報を取得するAPIの追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dist
 /.settings
 conf/prod.conf
 
+/bin

--- a/app/controllers/OrganizationController.scala
+++ b/app/controllers/OrganizationController.scala
@@ -1,0 +1,19 @@
+package controllers
+
+import models.OrganizationRepository
+import models.Organizations.organizationWrites
+import play.api.mvc.Controller
+import models.OrganizationId
+import scala.util.Failure
+import scala.util.Success
+import play.api.libs.json.Json
+
+object OrganizationController extends Controller with BaseController {
+  def getOrganization(id: Int) = Authenticated { request =>
+    val organizationRepository = new OrganizationRepository(garoonClient, request.user)
+    organizationRepository.resolve(OrganizationId(id.toString)) match {
+      case Success(user) => Ok(Json.toJson(user))
+      case Failure(e) => NotFound(Json.obj("message" -> "組織が見つかりませんでした"))
+    }
+  }
+}

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -6,10 +6,11 @@ import org.sisioh.dddbase.core.lifecycle.EntityNotFoundException
 import play.api.libs.json.Json
 import play.api.mvc.Controller
 import scala.util.{Failure, Success}
+import models.ExtendedUserRepository
 
 object UserController extends Controller with BaseController {
   def getCurrentUser = Authenticated { request =>
-    val userRepository = new UserRepository(garoonClient, request.user)
+    val userRepository = new ExtendedUserRepository(garoonClient, request.user)
 
     userRepository.getLoggedInUserId match {
       case Success(userId) =>
@@ -24,7 +25,7 @@ object UserController extends Controller with BaseController {
   }
 
   def getUser(id: Int) = Authenticated { request =>
-    val userRepository = new UserRepository(garoonClient, request.user)
+    val userRepository = new ExtendedUserRepository(garoonClient, request.user)
     userRepository.resolve(UserId(id.toString)) match {
       case Success(user) => Ok(Json.toJson(user))
       case Failure(e) => NotFound(Json.obj("message" -> "ユーザーが見つかりませんでした"))
@@ -32,7 +33,7 @@ object UserController extends Controller with BaseController {
   }
 
   def getUsersBy(loginNamesString: String) = Authenticated { request =>
-    val userRepository = new UserRepository(garoonClient, request.user)
+    val userRepository = new ExtendedUserRepository(garoonClient, request.user)
     val loginNames = loginNamesString.split(',').toSeq
     userRepository.findByLoginNames(loginNames) match {
       case Success(users) => Ok(Json.toJson(users))

--- a/app/models/ExtendedUser.scala
+++ b/app/models/ExtendedUser.scala
@@ -1,0 +1,78 @@
+package models
+
+import net.mtgto.garoon.user.User
+import net.mtgto.garoon.user.UserId
+import scala.xml.Node
+import net.mtgto.garoon.Authentication
+import org.sisioh.dddbase.core.lifecycle.EntityIOContext
+import org.sisioh.dddbase.core.lifecycle.sync.SyncEntityReader
+import net.mtgto.garoon.GaroonClient
+import scala.util.Try
+import scala.xml.XML
+import org.sisioh.dddbase.core.lifecycle.EntityNotFoundException
+
+trait ExtendedUser extends User {
+  val organizations: Array[String]
+  val primaryOrganization: String
+}
+
+object ExtendedUser {
+  private[this] case class DefaultUser(
+      identity: UserId, name: String, loginName: String,
+      organizations: Array[String], primaryOrganization: String)
+      extends ExtendedUser
+
+  def apply(node: Node): ExtendedUser = {
+    val identity = UserId((node \ "@key").text)
+    val name = (node \ "@name").text
+    val loginName = (node \ "@login_name").text
+    val organizations = (node \ "organization").map(n => (n \ "@id").text)
+    val primaryOrganization = (node \ "@primary_organization").text
+    DefaultUser(identity, name, loginName, organizations.toArray, primaryOrganization)
+  }
+}
+
+class ExtendedUserRepository(client: GaroonClient, auth: Authentication) extends SyncEntityReader[UserId, ExtendedUser] {
+  def resolve(identity: UserId)(implicit ctx: EntityIOContext[Try]): Try[ExtendedUser] = {
+    val actionName = "BaseGetUsersById"
+    val parameters = client.factory.createOMElement("parameters", null)
+    val eventNode = client.factory.createOMElement("user_id", null)
+    eventNode.setText(identity.value)
+    parameters.addChild(eventNode)
+
+    val result = client.sendReceive(actionName, "/cbpapi/base/api", parameters)(auth, None)
+    result.map { element =>
+      val node = XML.loadString(element.toString)
+      (node \ "returns" \ "user").map(ExtendedUser(_)).headOption.getOrElse(throw new EntityNotFoundException)
+    }
+  }
+
+  def containsByIdentity(identity: UserId)(implicit ctx: EntityIOContext[Try]): Try[Boolean] =
+    resolve(identity).map(_ => true)
+
+  def findByLoginNames(loginNames: Seq[String]): Try[Seq[ExtendedUser]] = {
+    val actionName = "BaseGetUsersByLoginName"
+    val parameters = client.factory.createOMElement("parameters", null)
+    loginNames.foreach { loginName =>
+      val loginNameNode = client.factory.createOMElement("login_name", null)
+      loginNameNode.setText(loginName)
+      parameters.addChild(loginNameNode)
+    }
+
+    val result = client.sendReceive(actionName, "/cbpapi/base/api", parameters)(auth, None)
+    result.map { element =>
+      val node = XML.loadString(element.toString)
+      (node \ "returns" \ "user").map(ExtendedUser(_))
+    }
+  }
+
+  def getLoggedInUserId: Try[UserId] = {
+    val actionName = "UtilGetLoginUserId"
+    val parameters = client.factory.createOMElement("parameters", null)
+    val result = client.sendReceive(actionName, "/util_api/util/api", parameters)(auth, None)
+    result.map { element =>
+      val node = XML.loadString(element.toString)
+      UserId((node \ "returns" \ "user_id").text)
+    }
+  }
+}

--- a/app/models/Organization.scala
+++ b/app/models/Organization.scala
@@ -1,0 +1,83 @@
+package models
+
+import scala.util.Try
+import scala.xml.Node
+import scala.xml.XML
+import org.sisioh.dddbase.core.lifecycle.EntityIOContext
+import org.sisioh.dddbase.core.lifecycle.EntityNotFoundException
+import org.sisioh.dddbase.core.lifecycle.sync.SyncEntityReader
+import net.mtgto.garoon.Authentication
+import net.mtgto.garoon.GaroonClient
+import net.mtgto.garoon.Id
+import net.mtgto.garoon.user.UserId
+import play.api.libs.json.JsValue
+import play.api.libs.json.Json
+import play.api.libs.json.Writes
+import org.sisioh.dddbase.core.model.Entity
+
+trait Organization extends Entity[OrganizationId] {
+  val identity: OrganizationId
+  val name: String
+  val description: String
+  val parentOrganization: Option[String]
+  val members: Array[UserId]
+}
+
+class OrganizationId(override val value: String) extends Id(value)
+
+object OrganizationId {
+  def apply(value: String): OrganizationId = new OrganizationId(value)
+}
+
+object Organization {
+  private[this] case class DefaultOrganization(
+      identity: OrganizationId, name: String, description: String,
+      parentOrganization: Option[String], members: Array[UserId])
+      extends Organization
+
+  def apply(node: Node): Organization = {
+    val identity = OrganizationId((node \ "@key").text)
+    val name = (node \ "@name").text
+    val description = (node \ "@description").text
+    val parentOrganization = (node \ "@parent_organization").text
+    val members = (node \ "members" \ "user").map(n => UserId((n \ "@id").text))
+    DefaultOrganization(identity, name, description,
+        Option(parentOrganization), members.toArray)
+  }
+}
+
+class OrganizationRepository(client: GaroonClient, auth: Authentication) extends SyncEntityReader[OrganizationId, Organization] {
+  def resolve(identity: OrganizationId)(implicit ctx: EntityIOContext[Try]): Try[Organization] = {
+    val actionName = "BaseGetOrganizationsById"
+    val parameters = client.factory.createOMElement("parameters", null)
+    val eventNode = client.factory.createOMElement("organization_id", null)
+    eventNode.setText(identity.value)
+    parameters.addChild(eventNode)
+
+    val result = client.sendReceive(actionName, "/cbpapi/base/api", parameters)(auth, None)
+    result.map { element =>
+      val node = XML.loadString(element.toString)
+      (node \ "returns" \ "organization").map(Organization(_)).headOption.getOrElse(throw new EntityNotFoundException)
+    }
+  }
+
+  def containsByIdentity(identity: OrganizationId)(implicit ctx: EntityIOContext[Try]): Try[Boolean] =
+    resolve(identity).map(_ => true)
+}
+
+/**
+ *  json writes
+ */
+object Organizations {
+  implicit val organizationWrites = new Writes[Organization] {
+    def writes(o: Organization): JsValue = {
+      Json.obj(
+        "id"                  -> o.identity.value,
+        "name"                -> o.name,
+        "description"         -> o.description,
+        "parent_organization" -> o.parentOrganization,
+        "members"             -> o.members.map(_.value)
+      )
+    }
+  }
+}

--- a/app/models/Users.scala
+++ b/app/models/Users.scala
@@ -1,15 +1,19 @@
 package models
 
-import play.api.libs.json.{JsValue, Json, Writes}
-import net.mtgto.garoon.user.User
+import net.mtgto.garoon.user.UserId
+import play.api.libs.json.JsValue
+import play.api.libs.json.Json
+import play.api.libs.json.Writes
 
 object Users {
-  implicit val userWrites = new Writes[User] {
-    def writes(u: User): JsValue = {
+  implicit val userWrites = new Writes[ExtendedUser] {
+    def writes(u: ExtendedUser): JsValue = {
       Json.obj(
         "id" -> u.identity.value,
         "name" -> u.name,
-        "login_name" -> u.loginName
+        "login_name" -> u.loginName,
+        "organizations" -> u.organizations,
+        "primary_organization" -> u.primaryOrganization
       )
     }
   }

--- a/conf/routes
+++ b/conf/routes
@@ -13,6 +13,7 @@ GET         /api/schedule/calendar/events              controllers.ScheduleContr
 GET         /api/user                                  controllers.UserController.getCurrentUser
 GET         /api/user/:id                              controllers.UserController.getUser(id: Int)
 GET         /api/user/login_name/:loginNames           controllers.UserController.getUsersBy(loginNames: String)
+GET         /api/organization/:id                      controllers.OrganizationController.getOrganization(id: Int)
 GET         /api/notification                          controllers.NotificationController.getNotifications(start: Long)
 POST        /api/notification/check                    controllers.NotificationController.checkNotifications(request_token: String)
 


### PR DESCRIPTION
### このpull requestが解決する問題
- ユーザ情報を取得するAPIのレスポンスに、所属組織リスト及び優先する組織の情報を追加します。
- BaseGetOrganizationsByIdをラップして組織情報を取得するAPIを追加します。
### 既知の問題
- Userクラス、UserRepositoryクラスが別リポジトリに分かれているので、暫定的に継承したクラスを追加しています。
